### PR TITLE
Throw exceptions in lambda

### DIFF
--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/ServerlessFunctionFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/ServerlessFunctionFileBuilder.kt
@@ -26,8 +26,7 @@ abstract class ServerlessFunctionFileBuilder(
     private val compilingElement: Element,
     inputType: Class<*>?,
     returnType: Class<*>?,
-    protected val classForReflectionService: ClassForReflectionService,
-    private val catchExceptions: Boolean = true
+    protected val classForReflectionService: ClassForReflectionService
 ): FileBuilder(), HandlerInformationProvider {
 
     private val messager: Messager = processingEnv.messager
@@ -118,7 +117,10 @@ abstract class ServerlessFunctionFileBuilder(
 
     protected abstract fun writeFunction(inputParam: Param, eventParam: Param)
 
-    protected abstract fun writeHandleError()
+    protected open fun writeHandleError() {
+        write("e.printStackTrace();")
+        write("throw e;")
+    }
 
     protected open fun writeCustomExceptionHandler() {}
 
@@ -207,23 +209,19 @@ abstract class ServerlessFunctionFileBuilder(
 
                 write("public $returnTypeSimpleName handleRequest($inputTypeSimpleName input, Context context) {")
 
-                if (catchExceptions) {
-                    write("try {")
-                }
+                write("try {")
 
                 write("String requestId = context.getAwsRequestId();")
 
                 writeFunction(params.inputParam, params.eventParam)
 
                 writeCustomExceptionHandler()
+                write("} catch (Exception e) {")
 
-                if (catchExceptions) {
-                    write("} catch (Exception e) {")
+                writeHandleError()
 
-                    writeHandleError()
+                write("}")
 
-                    write("}")
-                }
 
                 write("}")
 

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/basic/BasicServerlessFunctionFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/basic/BasicServerlessFunctionFileBuilder.kt
@@ -59,11 +59,6 @@ class BasicServerlessFunctionFileBuilder(
         }
     }
 
-    override fun writeHandleError() {
-        write("e.printStackTrace();")
-        write("return null;")
-    }
-
     override fun isValidFunction(functionParams: FunctionParams) {
         if (cron && !functionParams.inputParam.doesNotExist()) {
             compilationError("Cannot have a custom user type parameter in a BasicServerlessFunction")

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/deployment/DeploymentFunctionFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/deployment/DeploymentFunctionFileBuilder.kt
@@ -53,11 +53,6 @@ class DeploymentFunctionFileBuilder(
         }
     }
 
-    override fun writeHandleError() {
-        write("e.printStackTrace();")
-        write("return null;")
-    }
-
     override fun isValidFunction(functionParams: FunctionParams) {
         if (!functionParams.inputParam.doesNotExist()) {
             compilationError("Cannot have a custom user type in an AfterDeployment function")

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/file/FileStorageServerlessFunctionFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/file/FileStorageServerlessFunctionFileBuilder.kt
@@ -55,9 +55,4 @@ class FileStorageServerlessFunctionFileBuilder(
             compilationError("FileStorageServerlessFunction cannot have a custom user type, only a maximum of one FileStorageEvent type")
         }
     }
-
-    override fun writeHandleError() {
-        write("e.printStackTrace();")
-        write("return null;")
-    }
 }

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/http/HttpServerlessFunctionFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/http/HttpServerlessFunctionFileBuilder.kt
@@ -92,13 +92,6 @@ class HttpServerlessFunctionFileBuilder(
         write("return errorResponse;")
     }
 
-    override fun writeHandleError() {
-        write("e.printStackTrace();")
-        write("APIGatewayProxyResponseEvent errorResponse = new APIGatewayProxyResponseEvent().withStatusCode(500);")
-        addCorsHeader("errorResponse")
-        write("return errorResponse;")
-    }
-
     private fun addCorsHeader(variableName: String) {
         write("if ($variableName.getHeaders() == null) {")
         write("$variableName.setHeaders(new HashMap<>());")

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/notification/NotificationServerlessFunctionFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/notification/NotificationServerlessFunctionFileBuilder.kt
@@ -56,9 +56,4 @@ class NotificationServerlessFunctionFileBuilder(
         }
         write("return null;")
     }
-
-    override fun writeHandleError() {
-        write("e.printStackTrace();")
-        write("return null;")
-    }
 }

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/queue/QueueServerlessFunctionFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/queue/QueueServerlessFunctionFileBuilder.kt
@@ -23,8 +23,7 @@ class QueueServerlessFunctionFileBuilder(
     compilingElement,
     SQSEvent::class.java,
     Void::class.java,
-    classForReflectionService,
-    false
+    classForReflectionService
 ) {
 
     override fun generateClassName(): String {
@@ -99,10 +98,5 @@ class QueueServerlessFunctionFileBuilder(
             inputParam.index == 0 -> write("handler.$methodName($inputVariable, $eventVariable);")
             else -> write("handler.$methodName($eventVariable, $inputVariable);")
         }
-    }
-
-    override fun writeHandleError() {
-        write("e.printStackTrace();")
-        write("return null;")
     }
 }

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/store/StoreServerlessFunctionFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/store/StoreServerlessFunctionFileBuilder.kt
@@ -150,9 +150,4 @@ abstract class StoreServerlessFunctionFileBuilder(
             }
         }
     }
-
-    override fun writeHandleError() {
-        write("e.printStackTrace();")
-        write("return null;")
-    }
 }


### PR DESCRIPTION
Before, exceptions would be logged and then swallowed. This is fine when you are just looking at the logs, but at a certain scale it becomes difficult to find exceptions in cloudwatch. The swallowed exceptions wouldn't appear in the cloudwatch lambda error metrics, so finding exceptions can be difficult at a glance. This PR starts throwing exceptions so that the error metrics get correctly reported, which makes finding exceptions easier.