### PR TITLE
Support HTTP ByteArray return types to return binary data

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: maven
       - name: Build with Maven
         run: mvn --batch-mode verify
       - name: Run the action # You would run your tests before this using the output to set state/desc

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -2,26 +2,26 @@
 name: PR Tests
 
 on: [pull_request]
-      
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
       - name: Build with Maven
         run: mvn --batch-mode verify
       - name: Run the action # You would run your tests before this using the output to set state/desc
         uses: Sibz/github-status-action@v1
-        with: 
+        with:
           authToken: ${{secrets.GITHUB_TOKEN}}
           context: 'Test Run'
           description: 'Passed'
           state: 'success'
-          sha: ${{github.event.pull_request.head.sha || github.sha}}  
+          sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/cloud/aws/src/test/resources/handlers/HttpHandlers.java
+++ b/cloud/aws/src/test/resources/handlers/HttpHandlers.java
@@ -9,6 +9,7 @@ import models.NestedPerson;
 import models.People;
 
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class HttpHandlers {
@@ -63,6 +64,11 @@ public class HttpHandlers {
     return new People();
   }
 
+  @HttpServerlessFunction(method = HttpMethod.GET, path = "bytearrayresponse")
+  public byte[] byteArrayResponse() {
+    return  "test".getBytes();
+  }
+
   @HttpServerlessFunction(method = HttpMethod.GET, path = "encoderequest", enableRequestDecoding = true)
   public NestedPerson encodeRequest(Person person) {
     return new NestedPerson();
@@ -73,4 +79,8 @@ public class HttpHandlers {
     return new NestedPerson();
   }
 
+  @HttpServerlessFunction(method = HttpMethod.GET, path = "bytearrayencoderesponse", enableResponseEncoding = true)
+  public byte[] byteArrayEncodeResponse(HttpEvent event) {
+    return "test".getBytes();
+  }
 }

--- a/core/src/main/java/com/nimbusframework/nimbuscore/annotations/http/HttpUtils.kt
+++ b/core/src/main/java/com/nimbusframework/nimbuscore/annotations/http/HttpUtils.kt
@@ -59,17 +59,22 @@ object HttpUtils {
 
     @JvmStatic
     fun compressContent(httpEvent: HttpEvent, toCompress: String): CompressedContent? {
+        return compressContent(httpEvent.headers, toCompress.toByteArray())
+    }
+
+    @JvmStatic
+    fun compressContent(httpEvent: HttpEvent, toCompress: ByteArray): CompressedContent? {
         return compressContent(httpEvent.headers, toCompress)
     }
 
     @JvmStatic
-    fun compressContent(headers: Map<String, String>?, toCompress: String): CompressedContent? {
+    fun compressContent(headers: Map<String, String>?, toCompress: ByteArray): CompressedContent? {
         val chosenEncoding = getAcceptEncodings(headers) ?: return null
         val content = when (chosenEncoding) {
             ContentEncoding.GZIP -> {
                 val bos = ByteArrayOutputStream()
                 val compressionStream = GZIPOutputStream(bos)
-                compressionStream.write(toCompress.encodeToByteArray())
+                compressionStream.write(toCompress)
                 compressionStream.flush()
                 compressionStream.close()
                 bos.toByteArray()


### PR DESCRIPTION
Add support for returning binary data. Sent to API gateway as a base64 string, returned as binary blob over HTTP.

If compression is enabled, the byte array can be compressed directly without intermediate formatting.